### PR TITLE
Update basics-value-binding.md

### DIFF
--- a/Pages/basics-value-binding.md
+++ b/Pages/basics-value-binding.md
@@ -43,7 +43,8 @@ You cannot, for example, call methods from the value bindings.
 * `SomeCollection[6]`
 * `SomeCollection[6].OtherProperty`
 * `SomeProperty >= 0`
-* `SomeProperty ? "active" : ""`
+* `SomeProperty + 1`
+* `SomeProperty ? "some string" : "other string"`
 * `SomeProperty != OtherProperty`
 
 If you use the `ICollection.Count` or `Array.Length` property, they will be translated to JavaScript to use the `length` property on the JavaScript array.


### PR DESCRIPTION
pridany pripad ukazujuci iny ako porovnavaci operator
upravena ukazka ?: tak aby tam nebol zbytocne velmi konkretny string (z "" moze citatel nadobudnut dojem ze sa da porovnavat len s prazdnym stringom)