### PR TITLE
Update advanced-aspnetcore-authentication.md

### DIFF
--- a/Pages/advanced-aspnetcore-authentication.md
+++ b/Pages/advanced-aspnetcore-authentication.md
@@ -74,7 +74,7 @@ public class LoginViewModel : DotvvmViewModelBase
         {
             // the CreateIdentity is your own method which creates the IIdentity representing the user
             var identity = CreateIdentity(UserName);
-            await Context.GetAuthentication().SignInAsync("Cookie", new ClaimsPrincipal(identity));
+            await Context.GetAuthentication().SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(identity));
             Context.RedirectToRoute("Default");        
         }
     }


### PR DESCRIPTION
The hard coded Cookie value produces the following error in ASP.NET Core 2:
InvalidOperationException: No IAuthenticationSignInHandler is configured to handle sign in for the scheme: Cookie

The fix is to change it to CookieAuthenticationDefaults.AuthenticationScheme to match the settings as listed in the Startup.cs file.