### PR TITLE
service.AddDotvvm must include the class

### DIFF
--- a/Pages/basics-configuration.md
+++ b/Pages/basics-configuration.md
@@ -38,7 +38,7 @@ In ASP.NET Core, the registration of frameworks is splitted to the registration 
 In the `ConfigureServices` method, we should register DotVVM services:
 
 ```CSHARP
-services.AddDotVVM();
+services.AddDotVVM<DotvvmStartup>();
 ```
 
 In the `Configure` method we have to register the DotVVM middleware.


### PR DESCRIPTION
In order for it to work and to match other documentation (https://www.dotvvm.com/docs/tutorials/how-to-start-existing-app-aspnetcore/2.0) services.AddDotvvm should include the generic class in order to work.