### PR TITLE
Added swagger support for .NET Core 3.x

### DIFF
--- a/Pages/basics-rest-api-bindings-building-own-api.md
+++ b/Pages/basics-rest-api-bindings-building-own-api.md
@@ -23,7 +23,7 @@ Install-Package DotVVM.Api.Swashbuckle.Owin
 First, make sure you have Swashbuckle installed and configured in your project.
 
 * [Swashbuckle - ASP.NET Core](https://github.com/domaindrivendev/Swashbuckle.AspNetCore)
-* [Swashbuckle - ASP.NET Core - Newtonsoft](https://www.nuget.org/packages/Swashbuckle.AspNetCore.Newtonsoft/) (This package is necessary only for DotVVM 2.5+ projects that target ASP.NET Core < 3.0)
+* [Swashbuckle - ASP.NET Core - Newtonsoft](https://www.nuget.org/packages/Swashbuckle.AspNetCore.Newtonsoft/) (This package is necessary only for DotVVM 2.5+ projects that target ASP.NET Core 2.x, or that are using Newtonsoft.Json serializer with ASP.NET Core 3.x)
 
 Then install the following NuGet package to the REST API project:
 
@@ -67,7 +67,7 @@ services.AddSwaggerGen(options => {
 });
 ```
 
-Additionally, if you plan to use DotVVM 2.5+ with ASP.NET Core < 3.0, you also need to call `AddSwaggerGenNewtonsoftSupport`.
+Additionally, in case of DotVVM 2.5 or newer with ASP.NET Core 2.x or ASP.NET Core 3.x with Newtonsoft.Json serializer, you also need to call `AddSwaggerGenNewtonsoftSupport`.
 
 ```CSHARP
 services.AddSwaggerGenNewtonsoftSupport();

--- a/Pages/basics-rest-api-bindings-building-own-api.md
+++ b/Pages/basics-rest-api-bindings-building-own-api.md
@@ -10,7 +10,7 @@ These NuGet packages work with **Swashbuckle**, a popular library that exposes S
 
 First, make sure you have Swashbuckle installed and configured in your project. 
 
-* [Swashbuckle - ASP.NET Core](https://github.com/domaindrivendev/Swashbuckle.AspNetCore)
+* [Swashbuckle - classic ASP.NET](https://github.com/domaindrivendev/Swashbuckle) 
 
 Then, install the following NuGet package to the REST API project:
 
@@ -22,15 +22,13 @@ Install-Package DotVVM.Api.Swashbuckle.Owin
 
 First, make sure you have Swashbuckle installed and configured in your project.
 
-* [Swashbuckle - classic ASP.NET](https://github.com/domaindrivendev/Swashbuckle) 
+* [Swashbuckle - ASP.NET Core](https://github.com/domaindrivendev/Swashbuckle.AspNetCore)
+* [Swashbuckle - ASP.NET Core - Newtonsoft](https://www.nuget.org/packages/Swashbuckle.AspNetCore.Newtonsoft/) (This package is necessary only for DotVVM 2.5+ projects that target ASP.NET Core < 3.0)
 
-Then install the following NuGet package(s) to the REST API project:
+Then install the following NuGet package to the REST API project:
 
 ```
 Install-Package DotVVM.Api.Swashbuckle.AspNetCore
-
-# The following package is necessary for DotVVM 2.5+ projects that target ASP.NET Core < 3.0
-Install-Package Swashbuckle.AspNetCore.Newtonsoft
 ```
 
 ## Configure Swashbuckle extensions for DotVVM (OWIN)
@@ -69,33 +67,7 @@ services.AddSwaggerGen(options => {
 });
 ```
 
-Additionally from DotVVM 2.5, it is also necessary to override the default schema-naming strategy using the call to `CustomSchemaIds`.
-
-```CSHARP
-services.Configure<DotvvmApiOptions>(opt => 
-{
-    // TODO: configure DotVVM Swashbuckle options
-});
-
-string GetCustomSchemaId(Type modelType)
-{
-    if (!modelType.IsConstructedGenericType) return modelType.Name.Replace("[]", "Array");
-
-    var generics = modelType.GetGenericArguments()
-        .Select(genericArg => CustomSchemaId(genericArg))
-        .Aggregate((previous, current) => previous + current);
-
-    return $"{modelType.Name.Split('`').First()}[{generics}]";
-}
-
-services.AddSwaggerGen(options => {
-    ...
-    options.CustomSchemaIds(type => GetCustomSchemaId(type))
-    options.EnableDotvvmIntegration();
-});
-```
-
-Furthermore, if you plan to use DotVVM 2.5+ with ASP.NET Core < 3.0, you additionally need to call `AddSwaggerGenNewtonsoftSupport`.
+Additionally, if you plan to use DotVVM 2.5+ with ASP.NET Core < 3.0, you also need to call `AddSwaggerGenNewtonsoftSupport`.
 
 ```CSHARP
 services.AddSwaggerGenNewtonsoftSupport();

--- a/Pages/basics-rest-api-bindings-building-own-api.md
+++ b/Pages/basics-rest-api-bindings-building-own-api.md
@@ -29,7 +29,7 @@ Then install the following NuGet package(s) to the REST API project:
 ```
 Install-Package DotVVM.Api.Swashbuckle.AspNetCore
 
-# The following package should be added for DotVVM 2.5+ projects that target ASP.NET Core < 3.0
+# The following package is necessary for DotVVM 2.5+ projects that target ASP.NET Core < 3.0
 Install-Package Swashbuckle.AspNetCore.Newtonsoft
 ```
 
@@ -37,7 +37,7 @@ Install-Package Swashbuckle.AspNetCore.Newtonsoft
 
 To enable DotVVM integration, call the `EnableDotvvmIntegration` extension method in the Swashbuckle configuration.
 
-In OWIN, this is typically done in `SwaggerConfig.cs` file
+In OWIN, this is typically done in `SwaggerConfig.cs` file.
 
 ```CSHARP
 config.EnableSwagger(c =>
@@ -69,7 +69,7 @@ services.AddSwaggerGen(options => {
 });
 ```
 
-Additionally from DotVVM 2.5, it is also necessary to override default schema naming strategy using the call to `CustomSchemaIds`.
+Additionally from DotVVM 2.5, it is also necessary to override the default schema-naming strategy using the call to `CustomSchemaIds`.
 
 ```CSHARP
 services.Configure<DotvvmApiOptions>(opt => 

--- a/Pages/basics-rest-api-bindings-building-own-api.md
+++ b/Pages/basics-rest-api-bindings-building-own-api.md
@@ -33,14 +33,13 @@ Install-Package DotVVM.Api.Swashbuckle.AspNetCore
 Install-Package Swashbuckle.AspNetCore.Newtonsoft
 ```
 
-## Configure Swashbuckle extensions for DotVVM
+## Configure Swashbuckle extensions for DotVVM (OWIN)
 
 To enable DotVVM integration, call the `EnableDotvvmIntegration` extension method in the Swashbuckle configuration.
 
 In OWIN, this is typically done in `SwaggerConfig.cs` file
 
 ```CSHARP
-// OWIN
 config.EnableSwagger(c =>
     {
         ...
@@ -52,11 +51,27 @@ config.EnableSwagger(c =>
     .EnableSwaggerUi(c => { ... });
 ```
 
+## Configure Swashbuckle extensions for DotVVM (ASP.NET Core)
+
+To enable DotVVM integration, call the `EnableDotvvmIntegration` extension method in the Swashbuckle configuration.
+
 In ASP.NET Core, this is configured in `Startup.cs` file.
+
+```CSHARP
+services.Configure<DotvvmApiOptions>(opt => 
+{
+    // TODO: configure DotVVM Swashbuckle options
+});
+
+services.AddSwaggerGen(options => {
+    ...
+    options.EnableDotvvmIntegration();
+});
+```
+
 Additionally from DotVVM 2.5, it is also necessary to override default schema naming strategy using the call to `CustomSchemaIds`.
 
 ```CSHARP
-// ASP.NET Core
 services.Configure<DotvvmApiOptions>(opt => 
 {
     // TODO: configure DotVVM Swashbuckle options
@@ -78,6 +93,12 @@ services.AddSwaggerGen(options => {
     options.CustomSchemaIds(type => GetCustomSchemaId(type))
     options.EnableDotvvmIntegration();
 });
+```
+
+Furthermore, if you plan to use DotVVM 2.5+ with ASP.NET Core < 3.0, you additionally need to call `AddSwaggerGenNewtonsoftSupport`.
+
+```CSHARP
+services.AddSwaggerGenNewtonsoftSupport();
 ```
 
 ### Registering known types


### PR DESCRIPTION
This PR documents changes in installation and configuration related to package `DotVVM.Api.Swashbuckle.AspNetCore` and DotVVM 2.5+