### PR TITLE
Adjusted authorization example to better reflect differences between frameworks

### DIFF
--- a/Pages/upgrading-from-older-versions/from-3-2-to-4-0.md
+++ b/Pages/upgrading-from-older-versions/from-3-2-to-4-0.md
@@ -52,7 +52,11 @@ public class AdminViewModelBase : DotvvmViewModelBase
 
     public override async Task Init() 
     {
+        // ASP.NET Core has new asynchronous authorization API:
         await Context.Authorize();
+
+        // OWIN uses older blocking authorization API:
+        // Context.Authorize();
 
         await base.Init();  // always call base.Init() - another authorization checks can be specified in the base page 
     }

--- a/Pages/upgrading-from-older-versions/from-3-2-to-4-0.md
+++ b/Pages/upgrading-from-older-versions/from-3-2-to-4-0.md
@@ -55,7 +55,7 @@ public class AdminViewModelBase : DotvvmViewModelBase
         // ASP.NET Core has new asynchronous authorization API:
         await Context.Authorize();
 
-        // OWIN uses older blocking authorization API:
+        // OWIN has a synchronous Authorize method
         // Context.Authorize();
 
         await base.Init();  // always call base.Init() - another authorization checks can be specified in the base page 


### PR DESCRIPTION
There was a confusion for user on .NET Framework when upgrading to 4.0 as `async` API is available only for ASP.NET Core. Hopefully, this addition should make it more clear