### PR TITLE
BusinessPack ComboBox.AllowNewItems typo

### DIFF
--- a/Controls/businesspack/ComboBox/sample6/page.dothtml
+++ b/Controls/businesspack/ComboBox/sample6/page.dothtml
@@ -1,7 +1,7 @@
 <bp:ComboBox DataSource="{value: Countries}"
              Text="{value: TypedCountry}"
              SelectedValue="{value: SelectedCountry}"
-             AllowNewItem="true"
+             AllowNewItems="true"
              Placeholder="Please select or type Country" />
 
 <p>Selected Country: {{value: SelectedCountry ?? TypedCountry}}</p>

--- a/Controls/businesspack/ComboBox/sample6/sample.md
+++ b/Controls/businesspack/ComboBox/sample6/sample.md
@@ -1,6 +1,6 @@
 ## Sample 6: New Items
 
-To allow entering a custom value which is not present in the `DataSource` collection, you can use the `AllowNewItem` property. 
+To allow entering a custom value which is not present in the `DataSource` collection, you can use the `AllowNewItems` property. 
 
 The `Text` property contains the exact value the user entered in the text field.
 


### PR DESCRIPTION
Fixed typo in `ComboBox.AllowNewItems` - "s" was missing.