### PR TITLE
Adjust viewmodel documentation for 4.1

### DIFF
--- a/Controls/bootstrap/DataPager/sample1/ViewModel.cs
+++ b/Controls/bootstrap/DataPager/sample1/ViewModel.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ViewModel;
+using Newtonsoft.Json;
 
 namespace DotvvmWeb.Views.Docs.Controls.bootstrap.DataPager.sample1
 {
@@ -41,14 +42,7 @@ namespace DotvvmWeb.Views.Docs.Controls.bootstrap.DataPager.sample1
         public int Id { get; set; }
         public string Name { get; set; }
 
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
-
+        [JsonConstructor]
         public Customer(int id, string name)
         {
             Id = id;

--- a/Controls/bootstrap4/DataPager/sample1/ViewModel.cs
+++ b/Controls/bootstrap4/DataPager/sample1/ViewModel.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ViewModel;
+using Newtonsoft.Json;
 
 namespace DotvvmWeb.Views.Docs.Controls.bootstrap.DataPager.sample1
 {
@@ -41,14 +42,7 @@ namespace DotvvmWeb.Views.Docs.Controls.bootstrap.DataPager.sample1
         public int Id { get; set; }
         public string Name { get; set; }
 
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
-
+        [JsonConstructor]
         public Customer(int id, string name)
         {
             Id = id;

--- a/Controls/builtin/DataPager/sample1/ViewModel.cs
+++ b/Controls/builtin/DataPager/sample1/ViewModel.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ViewModel;
+using Newtonsoft.Json;
 
 namespace DotvvmWeb.Views.Docs.Controls.builtin.DataPager.sample1
 {
@@ -41,14 +42,7 @@ namespace DotvvmWeb.Views.Docs.Controls.builtin.DataPager.sample1
         public int Id { get; set; }
         public string Name { get; set; }
 
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
-
+        [JsonConstructor]
         public Customer(int id, string name)
         {
             Id = id;

--- a/Controls/builtin/DataPager/sample2/ViewModel.cs
+++ b/Controls/builtin/DataPager/sample2/ViewModel.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ViewModel;
+using Newtonsoft.Json;
 
 namespace DotvvmWeb.Views.Docs.Controls.builtin.DataPager.sample2
 {
@@ -40,14 +41,7 @@ namespace DotvvmWeb.Views.Docs.Controls.builtin.DataPager.sample2
         public int Id { get; set; }
         public string Name { get; set; }
 
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
-
+        [JsonConstructor]
         public Customer(int id, string name)
         {
             Id = id;

--- a/Controls/builtin/EmptyData/sample1/ViewModel.cs
+++ b/Controls/builtin/EmptyData/sample1/ViewModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ViewModel;
+using Newtonsoft.Json;
 
 namespace DotvvmWeb.Views.Docs.Controls.builtin.EmptyData.sample1
 {
@@ -18,14 +19,7 @@ namespace DotvvmWeb.Views.Docs.Controls.builtin.EmptyData.sample1
         public int Id { get; set; }
         public string Name { get; set; }
 
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
-
+        [JsonConstructor]
         public Customer(int id, string name)
         {
             Id = id;

--- a/Controls/builtin/GridView/sample1/ViewModel.cs
+++ b/Controls/builtin/GridView/sample1/ViewModel.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ViewModel;
+using Newtonsoft.Json;
 
 namespace DotvvmWeb.Views.Docs.Controls.builtin.GridView.sample1
 {
@@ -38,14 +39,8 @@ namespace DotvvmWeb.Views.Docs.Controls.builtin.GridView.sample1
         public int Id { get; set; }
         public string Name { get; set; }
 
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
 
+        [JsonConstructor]
         public Customer(int id, string name)
         {
             Id = id;

--- a/Controls/builtin/GridView/sample2/ViewModel.cs
+++ b/Controls/builtin/GridView/sample2/ViewModel.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ViewModel;
+using Newtonsoft.Json;
 
 namespace DotvvmWeb.Views.Docs.Controls.builtin.GridView.sample2
 {
@@ -40,14 +41,7 @@ namespace DotvvmWeb.Views.Docs.Controls.builtin.GridView.sample2
         public string Name { get; set; }
         public DateTime Date { get; set; }
 
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
-
+        [JsonConstructor]
         public Customer(int id, string name)
         {
             Id = id;

--- a/Controls/builtin/GridView/sample3/ViewModel.cs
+++ b/Controls/builtin/GridView/sample3/ViewModel.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ViewModel;
+using Newtonsoft.Json;
 
 namespace DotvvmWeb.Views.Docs.Controls.builtin.GridView.sample3
 {
@@ -38,14 +39,7 @@ namespace DotvvmWeb.Views.Docs.Controls.builtin.GridView.sample3
         public int Id { get; set; }
         public string Name { get; set; }
 
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
-
+        [JsonConstructor]
         public Customer(int id, string name)
         {
             Id = id;

--- a/Controls/builtin/GridView/sample4/ViewModel.cs
+++ b/Controls/builtin/GridView/sample4/ViewModel.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ViewModel;
+using Newtonsoft.Json;
 
 namespace DotvvmWeb.Views.Docs.Controls.builtin.GridView.sample4
 {
@@ -39,14 +40,7 @@ namespace DotvvmWeb.Views.Docs.Controls.builtin.GridView.sample4
         public int Id { get; set; }
         public string Name { get; set; }
 
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
-
+        [JsonConstructor]
         public Customer(int id, string name)
         {
             Id = id;

--- a/Controls/builtin/GridView/sample5/ViewModel.cs
+++ b/Controls/builtin/GridView/sample5/ViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using DotVVM.Framework.ViewModel;
+using Newtonsoft.Json;
 
 namespace DotvvmWeb.Views.Docs.Controls.builtin.GridView.Sample5
 {
@@ -23,14 +24,7 @@ namespace DotvvmWeb.Views.Docs.Controls.builtin.GridView.Sample5
         public int Id { get; set; }
         public string Name { get; set; }
 
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
-
+        [JsonConstructor]
         public Customer(int id, string name)
         {
             Id = id;

--- a/Controls/builtin/GridView/sample6/ViewModel.cs
+++ b/Controls/builtin/GridView/sample6/ViewModel.cs
@@ -51,23 +51,5 @@ namespace DotvvmWeb.Views.Docs.Controls.builtin.GridView.Sample6
         }
     }
 
-    public class Customer
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
-
-        public Customer(int id, string name)
-        {
-            Id = id;
-            Name = name;
-        }
-    }
+    public record Customer(int Id, string Name);
 }

--- a/Controls/businesspack/DataPager/sample1/Customer.cs
+++ b/Controls/businesspack/DataPager/sample1/Customer.cs
@@ -1,22 +1,4 @@
 ﻿namespace DotvvmWeb.Views.Docs.Controls.businesspack.DataPager.sample1
 {
-    public class Customer
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
-
-        public Customer(int id, string name)
-        {
-            Id = id;
-            Name = name;
-        }
-    }
+    public record Customer(int Id, string Name);
 }

--- a/Controls/businesspack/DataPager/sample2/Customer.cs
+++ b/Controls/businesspack/DataPager/sample2/Customer.cs
@@ -1,22 +1,4 @@
 namespace DotvvmWeb.Views.Docs.Controls.businesspack.DataPager.sample2
 {
-    public class Customer
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-
-        public Customer()
-        {
-            // NOTE: This default constructor is required. 
-            // Remember that the viewmodel is JSON-serialized
-            // which requires all objects to have a public 
-            // parameterless constructor
-        }
-
-        public Customer(int id, string name)
-        {
-            Id = id;
-            Name = name;
-        }
-    }
+    public record Customer(int Id, string Name);
 }

--- a/Pages/concepts/client-side-development/read-and-modify-viewmodel-from-js.md
+++ b/Pages/concepts/client-side-development/read-and-modify-viewmodel-from-js.md
@@ -98,10 +98,12 @@ dotvvm.serialization.serializeDate(date, convertToUtc);
 To convert DotVVM date representation to JavaScript `Date`, use the following function:
 
 ```JS
-dotvvm.globalize.parseDotvvmDate(date);
+dotvvm.serialization.parseDate(date, convertFromUtc);
 ```
 
-The coercer will convert `Date` to DotVVM string representation automatically, when you try to set the value. However, if you read the value, you'll see the string. If you need `Date`, use the `dotvvm.globalize.parseDotvvmDate` function.
+The coercer will convert `Date` to DotVVM string representation automatically, when you try to set the value. However, if you read the value, you'll see the string. If you need `Date`, use the `dotvvm.serialization.parseDate` function.
+
+Similarly, `TimeOnly` is stored as `HH:mm:ss` and `DateOnly` is stored as `yyyy-MM-dd`
 
 ### Time zone handling
 

--- a/Pages/concepts/viewmodels/overview.md
+++ b/Pages/concepts/viewmodels/overview.md
@@ -46,10 +46,11 @@ Therefore, the viewmodel can contain properties of the following types:
     * numeric types - `int` and `double` are preferred (you can use `byte`, `sbyte`, `short`, `ushort`, `uint`, `long`, `ulong`, `float`, and `decimal`, but the precision can be lost during the JSON serialization)
     * `bool`
     * `Guid`
-    * `DateTime`
+    * `DateTime`, `DateOnly` and `TimeOnly`
     * enums
 * nullable versions of supported primitive types (e. g. `int?`, `DateTime?`...)
 * objects with properties of supported types, and a public parameterless constructor
+* records with properties of supported types
 * collections of supported objects, or primitive types
     * Arrays: `T[]`
     * Lists: `List<T>`


### PR DESCRIPTION
* removed mentions that type needs to have parameterless constructor, and include records in some samples
* added TimeOnly and DateOnly to supported types