### PR TITLE
Added more information about DynamicData configuration

### DIFF
--- a/Pages/community-add-ons/dotvvm-dynamic-data.md
+++ b/Pages/community-add-ons/dotvvm-dynamic-data.md
@@ -43,6 +43,15 @@ public void ConfigureServices(IDotvvmServiceCollection options)
 }
 ```
 
+In case you did not provide the `dynamicDataConfig` (or it was `null`), you should call the `AddDynamicDataConfiguration` yourself. This will create a default configuration and register dynamic data controls for you. You can achieve this by adding the folowing line to the `DotvvmStartup.cs` file.
+
+```CSHARP
+private void ConfigureControls(DotvvmConfiguration config, string applicationPath)
+{
+    config.AddDynamicDataConfiguration();
+}
+```
+
 ## Add data annotations to model classes
 
 This will allow to provide UI metadata using the standard .NET Data Annotations attributes.


### PR DESCRIPTION
When following the guide, you can leave out the `dynamicDataConfig` parameter (as it appears to be optional). However, this results in incorrect configuration (for example the `dd` prefix is not registered, nor the dynamic data controls).

It appears that in this case users need to explicitly call the `AddDynamicDataConfiguration()` which creates a default configuration and registers the controls